### PR TITLE
64/yuchi/create tutorial UI

### DIFF
--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FloatingParticles } from "@/components/floating-particles";
 
@@ -164,16 +165,16 @@ export default function TutorialPage() {
       <FloatingParticles />
 
       <div className="relative z-20 min-h-svh px-6 py-8">
-        {/* Page number */}
-        <div className="absolute top-8 left-6 text-sm font-semibold tracking-[0.2em]">
-          <span className="text-[color:var(--gold-bright)]">
-            {formatPageNumber(index + 1)}
+        {/* Back link (match Play/Settings style) */}
+        <Link
+          href="/home"
+          className="absolute top-10 left-10 group flex items-center gap-2 text-[color:var(--gold-dim)] transition-colors hover:text-[color:var(--gold-bright)]"
+        >
+          <ChevronLeft className="w-5 h-5" />
+          <span className="text-xs uppercase tracking-widest text-shadow-glow">
+            Back
           </span>
-          <span className="text-[color:var(--gold-dim)]"> / </span>
-          <span className="text-[color:var(--gold-dim)]">
-            {formatPageNumber(total)}
-          </span>
-        </div>
+        </Link>
 
         {/* Center area (carousel) */}
         <div className="min-h-svh flex items-center justify-center">
@@ -212,6 +213,17 @@ export default function TutorialPage() {
         </div>
 
         {/* Bottom controls */}
+        {/* Page number (bottom center, slightly above controls) */}
+        <div className="absolute left-0 right-0 bottom-24 flex items-center justify-center text-sm font-semibold tracking-[0.2em]">
+          <span className="text-[color:var(--gold-bright)]">
+            {formatPageNumber(index + 1)}
+          </span>
+          <span className="text-[color:var(--gold-dim)]"> / </span>
+          <span className="text-[color:var(--gold-dim)]">
+            {formatPageNumber(total)}
+          </span>
+        </div>
+
         <div className="absolute left-0 right-0 bottom-10 flex items-center justify-center gap-6">
           <button
             type="button"

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -77,6 +77,22 @@ export default function TutorialPage() {
     "idle",
   );
   const rafRef = useRef<number | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(mq.matches);
+    update();
+
+    // Safari fallback: addListener/removeListener
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", update);
+      return () => mq.removeEventListener("change", update);
+    }
+
+    mq.addListener(update);
+    return () => mq.removeListener(update);
+  }, []);
 
   const isAnimating = phase !== "idle";
   const canPrev = index > 0 && !isAnimating;
@@ -84,9 +100,20 @@ export default function TutorialPage() {
 
   const startTransition = useCallback(
     (nextIndex: number, nextDirection: "next" | "prev") => {
-      if (isAnimating) return;
       if (nextIndex === index) return;
       if (nextIndex < 0 || nextIndex >= total) return;
+
+      // Accessibility: if the user prefers reduced motion, switch immediately.
+      if (prefersReducedMotion) {
+        if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+        setDirection(nextDirection);
+        setPendingIndex(null);
+        setPhase("idle");
+        setIndex(nextIndex);
+        return;
+      }
+
+      if (isAnimating) return;
 
       setDirection(nextDirection);
       setPendingIndex(nextIndex);
@@ -100,7 +127,7 @@ export default function TutorialPage() {
         setPhase("animating");
       });
     },
-    [index, isAnimating, total],
+    [index, isAnimating, prefersReducedMotion, total],
   );
 
   const goPrev = useCallback(() => {
@@ -143,10 +170,11 @@ export default function TutorialPage() {
   const incomingFromX = direction === "next" ? 100 : -100;
   const incomingToX = 0;
 
-  const currentX = phase === "animating" ? currentToX : currentFromX;
-  const incomingX = phase === "animating" ? incomingToX : incomingFromX;
+  const shouldAnimate = !prefersReducedMotion && phase === "animating";
+  const currentX = shouldAnimate ? currentToX : currentFromX;
+  const incomingX = shouldAnimate ? incomingToX : incomingFromX;
 
-  const enableTransition = phase === "animating";
+  const enableTransition = shouldAnimate;
 
   useEffect(() => {
     if (phase !== "reset") return;

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -209,7 +209,7 @@ export default function TutorialPage() {
                 className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
                 style={{ transform: `translateX(${currentX}%)` }}
               >
-                <SlideContent slide={activeSlide} pageNumber={index + 1} />
+                <SlideContent slide={activeSlide} />
               </div>
 
               {/* Incoming slide (only during transition) */}
@@ -225,10 +225,7 @@ export default function TutorialPage() {
                     setPhase("reset");
                   }}
                 >
-                  <SlideContent
-                    slide={nextSlide}
-                    pageNumber={pendingIndex + 1}
-                  />
+                  <SlideContent slide={nextSlide} />
                 </div>
               )}
             </div>
@@ -290,13 +287,7 @@ export default function TutorialPage() {
   );
 }
 
-function SlideContent({
-  slide,
-  pageNumber,
-}: {
-  slide: TutorialSlide;
-  pageNumber: number;
-}) {
+function SlideContent({ slide }: { slide: TutorialSlide }) {
   const [imageError, setImageError] = useState(false);
 
   return (
@@ -328,10 +319,6 @@ function SlideContent({
           </div>
         )}
       </div>
-
-      <h2 className="text-center text-3xl font-bold tracking-[0.18em] text-[color:var(--gold-bright)]">
-        ページ {pageNumber}
-      </h2>
 
       <p className="text-center text-base leading-relaxed tracking-wide text-[color:var(--foreground)]/90">
         {slide.description}

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -322,19 +322,27 @@ export default function TutorialPage() {
 
 function SlideContent({ slide }: { slide: TutorialSlide }) {
   const [imageError, setImageError] = useState(false);
+  const hasImageSrc = Boolean(slide.imageSrc);
+  const showImage = hasImageSrc && !imageError;
+
+  useEffect(() => {
+    setImageError(false);
+  }, [slide.imageSrc]);
 
   return (
     <div className="h-full w-full px-2 sm:px-6 flex flex-col items-center justify-center gap-5 sm:gap-7">
       <div className="relative w-full max-w-3xl h-[min(360px,32svh)] overflow-hidden rounded-2xl border border-[color:var(--gold)]/18 bg-black/10">
-        <Image
-          src={slide.imageSrc}
-          alt={slide.imageAlt}
-          fill
-          className="object-cover"
-          sizes="(max-width: 768px) 92vw, 960px"
-          priority
-          onError={() => setImageError(true)}
-        />
+        {showImage && (
+          <Image
+            src={slide.imageSrc}
+            alt={slide.imageAlt}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 92vw, 960px"
+            priority
+            onError={() => setImageError(true)}
+          />
+        )}
         <div
           className="absolute inset-0"
           style={{
@@ -344,7 +352,7 @@ function SlideContent({ slide }: { slide: TutorialSlide }) {
           aria-hidden="true"
         />
 
-        {(!slide.imageSrc || imageError) && (
+        {!showImage && (
           <div className="absolute inset-0 grid place-items-center">
             <span className="text-sm tracking-[0.25em] text-[color:var(--gold-dim)]/80">
               画像がここに表示されます

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -12,10 +12,6 @@ type TutorialSlide = {
   description: string;
 };
 
-function formatPageNumber(n: number) {
-  return String(n).padStart(2, "0");
-}
-
 export default function TutorialPage() {
   const slides = useMemo<TutorialSlide[]>(
     () => [
@@ -204,54 +200,43 @@ export default function TutorialPage() {
         </header>
 
         {/* Center area (carousel) */}
-        <div className="h-full flex items-center justify-center">
-          <div className="w-full max-w-sm">
-            <div className="relative overflow-hidden rounded-2xl border border-[color:var(--gold)]/15 bg-black/20 backdrop-blur-sm">
-              <div className="relative h-[360px]">
-                {/* Current slide */}
-                <div
-                  key={index}
-                  className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
-                  style={{ transform: `translateX(${currentX}%)` }}
-                >
-                  <SlideContent slide={activeSlide} />
-                </div>
-
-                {/* Incoming slide (only during transition) */}
-                {nextSlide && (
-                  <div
-                    key={pendingIndex}
-                    className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
-                    style={{ transform: `translateX(${incomingX}%)` }}
-                    onTransitionEnd={(e) => {
-                      if (e.target !== e.currentTarget) return;
-                      if (pendingIndex === null) return;
-                      setIndex(pendingIndex);
-                      setPendingIndex(null);
-                      setPhase("reset");
-                    }}
-                  >
-                    <SlideContent slide={nextSlide} />
-                  </div>
-                )}
+        <div className="h-full flex items-start justify-center pt-32 pb-36">
+          <div className="w-full max-w-4xl">
+            <div className="relative h-[min(520px,62svh)] overflow-hidden">
+              {/* Current slide */}
+              <div
+                key={index}
+                className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
+                style={{ transform: `translateX(${currentX}%)` }}
+              >
+                <SlideContent slide={activeSlide} pageNumber={index + 1} />
               </div>
+
+              {/* Incoming slide (only during transition) */}
+              {nextSlide && pendingIndex !== null && (
+                <div
+                  key={pendingIndex}
+                  className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
+                  style={{ transform: `translateX(${incomingX}%)` }}
+                  onTransitionEnd={(e) => {
+                    if (e.target !== e.currentTarget) return;
+                    setIndex(pendingIndex);
+                    setPendingIndex(null);
+                    setPhase("reset");
+                  }}
+                >
+                  <SlideContent
+                    slide={nextSlide}
+                    pageNumber={pendingIndex + 1}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>
 
         {/* Bottom controls */}
-        {/* Page number (bottom center, slightly above controls) */}
-        <div className="absolute left-0 right-0 bottom-24 flex items-center justify-center text-sm font-semibold tracking-[0.2em]">
-          <span className="text-[color:var(--gold-bright)]">
-            {formatPageNumber(index + 1)}
-          </span>
-          <span className="text-[color:var(--gold-dim)]"> / </span>
-          <span className="text-[color:var(--gold-dim)]">
-            {formatPageNumber(total)}
-          </span>
-        </div>
-
-        <div className="absolute left-0 right-0 bottom-10 flex items-center justify-center gap-6">
+        <div className="absolute left-0 right-0 bottom-14 flex items-center justify-center gap-6">
           <button
             type="button"
             onClick={goPrev}
@@ -266,18 +251,24 @@ export default function TutorialPage() {
             className="flex items-center gap-2"
             aria-label="ページインジケーター"
           >
-            {slides.map((_, i) => (
-              <div
-                // indicator only (no click per spec)
-                key={i}
-                className="h-2 w-2 rounded-full"
-                style={{
-                  backgroundColor:
-                    i === index ? "var(--gold-bright)" : "var(--gold-dim)",
-                  opacity: i === index ? 1 : 0.35,
-                }}
-              />
-            ))}
+            {slides.map((_, i) => {
+              const isActive = i === index;
+              return (
+                <div
+                  // indicator only (no click per spec)
+                  key={i}
+                  className={
+                    isActive ? "h-2 w-8 rounded-full" : "h-2 w-2 rounded-full"
+                  }
+                  style={{
+                    backgroundColor: isActive
+                      ? "var(--gold-bright)"
+                      : "var(--gold-dim)",
+                    opacity: isActive ? 1 : 0.35,
+                  }}
+                />
+              );
+            })}
           </div>
 
           <button
@@ -290,22 +281,35 @@ export default function TutorialPage() {
             <ChevronRight className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
           </button>
         </div>
+
+        <div className="absolute left-0 right-0 bottom-6 text-center text-xs tracking-[0.22em] text-[color:var(--gold-dim)]/80">
+          ←→キーでもページ移動できます
+        </div>
       </div>
     </main>
   );
 }
 
-function SlideContent({ slide }: { slide: TutorialSlide }) {
+function SlideContent({
+  slide,
+  pageNumber,
+}: {
+  slide: TutorialSlide;
+  pageNumber: number;
+}) {
+  const [imageError, setImageError] = useState(false);
+
   return (
-    <div className="h-full w-full p-5 flex flex-col items-center justify-center gap-5">
-      <div className="relative w-full max-w-xs aspect-[4/3] overflow-hidden rounded-xl border border-[color:var(--gold)]/15">
+    <div className="h-full w-full px-6 flex flex-col items-center justify-start gap-7">
+      <div className="relative w-full max-w-3xl aspect-[16/9] overflow-hidden rounded-2xl border border-[color:var(--gold)]/18 bg-black/10">
         <Image
           src={slide.imageSrc}
           alt={slide.imageAlt}
           fill
           className="object-cover"
-          sizes="(max-width: 768px) 80vw, 320px"
+          sizes="(max-width: 768px) 92vw, 960px"
           priority
+          onError={() => setImageError(true)}
         />
         <div
           className="absolute inset-0"
@@ -315,7 +319,19 @@ function SlideContent({ slide }: { slide: TutorialSlide }) {
           }}
           aria-hidden="true"
         />
+
+        {(!slide.imageSrc || imageError) && (
+          <div className="absolute inset-0 grid place-items-center">
+            <span className="text-sm tracking-[0.25em] text-[color:var(--gold-dim)]/80">
+              画像がここに表示されます
+            </span>
+          </div>
+        )}
       </div>
+
+      <h2 className="text-center text-3xl font-bold tracking-[0.18em] text-[color:var(--gold-bright)]">
+        ページ {pageNumber}
+      </h2>
 
       <p className="text-center text-base leading-relaxed tracking-wide text-[color:var(--foreground)]/90">
         {slide.description}

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -207,30 +207,33 @@ export default function TutorialPage() {
 
       <FloatingParticles />
 
-      <div className="relative z-20 h-full overflow-hidden px-10">
-        {/* Back link (match Play/Settings style) */}
-        <Link
-          href="/home"
-          className="absolute top-10 left-10 group flex items-center gap-2 text-[color:var(--gold-dim)] transition-colors hover:text-[color:var(--gold-bright)]"
-        >
-          <ChevronLeft className="w-5 h-5" />
-          <span className="text-xs uppercase tracking-widest text-shadow-glow">
-            Back
-          </span>
-        </Link>
+      <div className="relative z-20 h-full overflow-hidden px-6 sm:px-10 flex flex-col">
+        {/* Top area */}
+        <div className="relative pt-8 sm:pt-10 flex-none">
+          {/* Back link (match Play/Settings style) */}
+          <Link
+            href="/home"
+            className="absolute left-0 top-8 sm:top-10 group flex items-center gap-2 text-[color:var(--gold-dim)] transition-colors hover:text-[color:var(--gold-bright)]"
+          >
+            <ChevronLeft className="w-5 h-5" />
+            <span className="text-xs uppercase tracking-widest text-shadow-glow">
+              Back
+            </span>
+          </Link>
 
-        {/* Title (top center) */}
-        <header className="absolute top-10 left-1/2 -translate-x-1/2 text-center">
-          <BookOpen className="w-10 h-10 mx-auto mb-3 text-[color:var(--gold)] opacity-80" />
-          <h1 className="text-2xl font-bold tracking-[0.4em] text-[color:var(--gold-bright)] uppercase">
-            Tutorial
-          </h1>
-        </header>
+          {/* Title (top center) */}
+          <header className="text-center">
+            <BookOpen className="w-9 h-9 sm:w-10 sm:h-10 mx-auto mb-2 sm:mb-3 text-[color:var(--gold)] opacity-80" />
+            <h1 className="text-xl sm:text-2xl font-bold tracking-[0.4em] text-[color:var(--gold-bright)] uppercase">
+              Tutorial
+            </h1>
+          </header>
+        </div>
 
         {/* Center area (carousel) */}
-        <div className="h-full flex items-start justify-center pt-32 pb-36">
-          <div className="w-full max-w-4xl">
-            <div className="relative h-[min(520px,62svh)] overflow-hidden">
+        <div className="flex-1 min-h-0 flex items-center justify-center py-6 sm:py-10">
+          <div className="w-full max-w-4xl h-full min-h-0">
+            <div className="relative h-full min-h-0 overflow-hidden">
               {/* Current slide */}
               <div
                 key={index}
@@ -261,54 +264,56 @@ export default function TutorialPage() {
         </div>
 
         {/* Bottom controls */}
-        <div className="absolute left-0 right-0 bottom-14 flex items-center justify-center gap-6">
-          <button
-            type="button"
-            onClick={goPrev}
-            disabled={!canPrev}
-            className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
-            aria-label="前のページ"
-          >
-            <ChevronLeft className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
-          </button>
+        <div className="flex-none pb-6 sm:pb-8">
+          <div className="flex items-center justify-center gap-6">
+            <button
+              type="button"
+              onClick={goPrev}
+              disabled={!canPrev}
+              className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
+              aria-label="前のページ"
+            >
+              <ChevronLeft className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
+            </button>
 
-          <div
-            className="flex items-center gap-2"
-            aria-label="ページインジケーター"
-          >
-            {slides.map((_, i) => {
-              const isActive = i === index;
-              return (
-                <div
-                  // indicator only (no click per spec)
-                  key={i}
-                  className={
-                    isActive ? "h-2 w-8 rounded-full" : "h-2 w-2 rounded-full"
-                  }
-                  style={{
-                    backgroundColor: isActive
-                      ? "var(--gold-bright)"
-                      : "var(--gold-dim)",
-                    opacity: isActive ? 1 : 0.35,
-                  }}
-                />
-              );
-            })}
+            <div
+              className="flex items-center gap-2"
+              aria-label="ページインジケーター"
+            >
+              {slides.map((_, i) => {
+                const isActive = i === index;
+                return (
+                  <div
+                    // indicator only (no click per spec)
+                    key={i}
+                    className={
+                      isActive ? "h-2 w-8 rounded-full" : "h-2 w-2 rounded-full"
+                    }
+                    style={{
+                      backgroundColor: isActive
+                        ? "var(--gold-bright)"
+                        : "var(--gold-dim)",
+                      opacity: isActive ? 1 : 0.35,
+                    }}
+                  />
+                );
+              })}
+            </div>
+
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={!canNext}
+              className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
+              aria-label="次のページ"
+            >
+              <ChevronRight className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
+            </button>
           </div>
 
-          <button
-            type="button"
-            onClick={goNext}
-            disabled={!canNext}
-            className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
-            aria-label="次のページ"
-          >
-            <ChevronRight className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
-          </button>
-        </div>
-
-        <div className="absolute left-0 right-0 bottom-6 text-center text-xs tracking-[0.22em] text-[color:var(--gold-dim)]/80">
-          ←→キーでもページ移動できます
+          <div className="mt-3 text-center text-xs tracking-[0.22em] text-[color:var(--gold-dim)]/80">
+            ←→キーでもページ移動できます
+          </div>
         </div>
       </div>
     </main>
@@ -319,8 +324,8 @@ function SlideContent({ slide }: { slide: TutorialSlide }) {
   const [imageError, setImageError] = useState(false);
 
   return (
-    <div className="h-full w-full px-6 flex flex-col items-center justify-start gap-7">
-      <div className="relative w-full max-w-3xl aspect-[16/9] overflow-hidden rounded-2xl border border-[color:var(--gold)]/18 bg-black/10">
+    <div className="h-full w-full px-2 sm:px-6 flex flex-col items-center justify-center gap-5 sm:gap-7">
+      <div className="relative w-full max-w-3xl h-[min(360px,32svh)] overflow-hidden rounded-2xl border border-[color:var(--gold)]/18 bg-black/10">
         <Image
           src={slide.imageSrc}
           alt={slide.imageAlt}

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { BookOpen, ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -194,6 +194,14 @@ export default function TutorialPage() {
             Back
           </span>
         </Link>
+
+        {/* Title (top center) */}
+        <header className="absolute top-10 left-1/2 -translate-x-1/2 text-center">
+          <BookOpen className="w-10 h-10 mx-auto mb-3 text-[color:var(--gold)] opacity-80" />
+          <h1 className="text-2xl font-bold tracking-[0.4em] text-[color:var(--gold-bright)] uppercase">
+            Tutorial
+          </h1>
+        </header>
 
         {/* Center area (carousel) */}
         <div className="min-h-svh flex items-center justify-center">

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -162,9 +162,28 @@ export default function TutorialPage() {
 
   return (
     <main className="relative min-h-svh w-full overflow-hidden bg-[color:var(--background)] text-[color:var(--foreground)]">
+      {/* Background layers (match Home ambience) */}
+      <div
+        className="fixed inset-0"
+        style={{ background: "var(--background)", opacity: 0.3 }}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed inset-0"
+        style={{
+          background:
+            "linear-gradient(to bottom, rgba(0,0,0,0.25), rgba(0,0,0,0.15), rgba(0,0,0,0.35))",
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed inset-0 shadow-[inset_0_0_200px_80px_rgba(0,0,0,0.6)]"
+        aria-hidden="true"
+      />
+
       <FloatingParticles />
 
-      <div className="relative z-20 min-h-svh px-6 py-8">
+      <div className="relative z-20 min-h-svh px-10 py-8">
         {/* Back link (match Play/Settings style) */}
         <Link
           href="/home"
@@ -178,9 +197,9 @@ export default function TutorialPage() {
 
         {/* Center area (carousel) */}
         <div className="min-h-svh flex items-center justify-center">
-          <div className="w-full max-w-md">
+          <div className="w-full max-w-sm">
             <div className="relative overflow-hidden rounded-2xl border border-[color:var(--gold)]/15 bg-black/20 backdrop-blur-sm">
-              <div className="relative h-[420px]">
+              <div className="relative h-[360px]">
                 {/* Current slide */}
                 <div
                   key={index}
@@ -270,14 +289,14 @@ export default function TutorialPage() {
 
 function SlideContent({ slide }: { slide: TutorialSlide }) {
   return (
-    <div className="h-full w-full p-6 flex flex-col items-center justify-center gap-6">
-      <div className="relative w-full max-w-sm aspect-[4/3] overflow-hidden rounded-xl border border-[color:var(--gold)]/15">
+    <div className="h-full w-full p-5 flex flex-col items-center justify-center gap-5">
+      <div className="relative w-full max-w-xs aspect-[4/3] overflow-hidden rounded-xl border border-[color:var(--gold)]/15">
         <Image
           src={slide.imageSrc}
           alt={slide.imageAlt}
           fill
           className="object-cover"
-          sizes="(max-width: 768px) 80vw, 420px"
+          sizes="(max-width: 768px) 80vw, 320px"
           priority
         />
         <div

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -1,59 +1,286 @@
 "use client";
 
-import { ChevronLeft, BookOpen, Sparkles } from "lucide-react";
-import Link from "next/link";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Image from "next/image";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FloatingParticles } from "@/components/floating-particles";
 
+type TutorialSlide = {
+  imageSrc: string;
+  imageAlt: string;
+  description: string;
+};
+
+function formatPageNumber(n: number) {
+  return String(n).padStart(2, "0");
+}
+
 export default function TutorialPage() {
+  const slides = useMemo<TutorialSlide[]>(
+    () => [
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "杖の準備",
+        description: "杖を手に取り、姿勢を整えましょう。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "接続の確認",
+        description: "デバイスが接続できているか確認します。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "魔力の集中",
+        description: "深呼吸して、魔力を一点に集めます。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "呪文の詠唱",
+        description: "呪文をはっきり唱えてください。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "ジェスチャー",
+        description: "杖で合図の動きを描きます。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "発動の合図",
+        description: "光が集まったら、発動のタイミングです。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "結果の確認",
+        description: "反応が出たか、目と耳で確かめます。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "再調整",
+        description: "うまくいかない時は、距離と向きを調整します。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "連携",
+        description: "魔法は道具と連携して強くなります。",
+      },
+      {
+        imageSrc: "/yuchimage/yuchisiro.jpg",
+        imageAlt: "準備完了",
+        description: "準備完了。次はプレイ画面で実際に試しましょう。",
+      },
+    ],
+    [],
+  );
+
+  const total = slides.length;
+  const [index, setIndex] = useState(0);
+  const [pendingIndex, setPendingIndex] = useState<number | null>(null);
+  const [direction, setDirection] = useState<"next" | "prev">("next");
+  const [phase, setPhase] = useState<"idle" | "prep" | "animating" | "reset">(
+    "idle",
+  );
+  const rafRef = useRef<number | null>(null);
+
+  const isAnimating = phase !== "idle";
+  const canPrev = index > 0 && !isAnimating;
+  const canNext = index < total - 1 && !isAnimating;
+
+  const startTransition = useCallback(
+    (nextIndex: number, nextDirection: "next" | "prev") => {
+      if (isAnimating) return;
+      if (nextIndex === index) return;
+      if (nextIndex < 0 || nextIndex >= total) return;
+
+      setDirection(nextDirection);
+      setPendingIndex(nextIndex);
+      setPhase("prep");
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = requestAnimationFrame(() => {
+        // 次フレームで「移動後」のtransformに切り替えてトランジションを確実に発火させる
+        setPhase("animating");
+      });
+    },
+    [index, isAnimating, total],
+  );
+
+  const goPrev = useCallback(() => {
+    if (!canPrev) return;
+    startTransition(index - 1, "prev");
+  }, [canPrev, index, startTransition]);
+
+  const goNext = useCallback(() => {
+    if (!canNext) return;
+    startTransition(index + 1, "next");
+  }, [canNext, index, startTransition]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isAnimating) return;
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goPrev();
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goNext();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [goNext, goPrev, isAnimating]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  const activeSlide = slides[index];
+  const nextSlide = pendingIndex !== null ? slides[pendingIndex] : null;
+
+  const currentFromX = 0;
+  const currentToX = direction === "next" ? -100 : 100;
+  const incomingFromX = direction === "next" ? 100 : -100;
+  const incomingToX = 0;
+
+  const currentX = phase === "animating" ? currentToX : currentFromX;
+  const incomingX = phase === "animating" ? incomingToX : incomingFromX;
+
+  const enableTransition = phase === "animating";
+
+  useEffect(() => {
+    if (phase !== "reset") return;
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      setPhase("idle");
+    });
+  }, [phase]);
+
   return (
     <main className="relative min-h-svh w-full overflow-hidden bg-[color:var(--background)] text-[color:var(--foreground)]">
       <FloatingParticles />
 
-      <div className="relative z-20 flex flex-col min-h-svh items-center justify-center px-10">
-        {/* Back link */}
-        <Link
-          href="/home"
-          className="absolute top-10 left-10 group flex items-center gap-2 text-[color:var(--gold-dim)] transition-colors hover:text-[color:var(--gold-bright)]"
-        >
-          <ChevronLeft className="w-5 h-5" />
-          <span className="text-xs uppercase tracking-widest text-shadow-glow">
-            Back
+      <div className="relative z-20 min-h-svh px-6 py-8">
+        {/* Page number */}
+        <div className="absolute top-8 left-6 text-sm font-semibold tracking-[0.2em]">
+          <span className="text-[color:var(--gold-bright)]">
+            {formatPageNumber(index + 1)}
           </span>
-        </Link>
+          <span className="text-[color:var(--gold-dim)]"> / </span>
+          <span className="text-[color:var(--gold-dim)]">
+            {formatPageNumber(total)}
+          </span>
+        </div>
 
-        <header className="mb-12 text-center">
-          <BookOpen
-            className="w-10 h-10 mx-auto mb-4 opacity-80"
-            style={{ color: "var(--gold)" }}
-          />
-          <h1 className="text-2xl font-bold tracking-[0.3em] text-[color:var(--gold-bright)] uppercase">
-            Tutorial
-          </h1>
-        </header>
+        {/* Center area (carousel) */}
+        <div className="min-h-svh flex items-center justify-center">
+          <div className="w-full max-w-md">
+            <div className="relative overflow-hidden rounded-2xl border border-[color:var(--gold)]/15 bg-black/20 backdrop-blur-sm">
+              <div className="relative h-[420px]">
+                {/* Current slide */}
+                <div
+                  key={index}
+                  className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
+                  style={{ transform: `translateX(${currentX}%)` }}
+                >
+                  <SlideContent slide={activeSlide} />
+                </div>
 
-        <ul className="w-full max-w-sm space-y-8 font-serif leading-relaxed">
-          <SimpleStep num="01" text="杖を手に、深呼吸をしてください。" />
-          <SimpleStep num="02" text="呪文を唱え、正しい動きを加えます。" />
-          <SimpleStep num="03" text="光とともに、魔法が顕現します。" />
-        </ul>
+                {/* Incoming slide (only during transition) */}
+                {nextSlide && (
+                  <div
+                    key={pendingIndex}
+                    className={`absolute inset-0 ${enableTransition ? "transition-transform duration-500 ease-in-out" : ""}`}
+                    style={{ transform: `translateX(${incomingX}%)` }}
+                    onTransitionEnd={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (pendingIndex === null) return;
+                      setIndex(pendingIndex);
+                      setPendingIndex(null);
+                      setPhase("reset");
+                    }}
+                  >
+                    <SlideContent slide={nextSlide} />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
 
-        <div className="absolute bottom-20 mt-10 animate-pulse text-[color:var(--gold)]/60">
-          <Sparkles className="w-6 h-6" />
+        {/* Bottom controls */}
+        <div className="absolute left-0 right-0 bottom-10 flex items-center justify-center gap-6">
+          <button
+            type="button"
+            onClick={goPrev}
+            disabled={!canPrev}
+            className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
+            aria-label="前のページ"
+          >
+            <ChevronLeft className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
+          </button>
+
+          <div
+            className="flex items-center gap-2"
+            aria-label="ページインジケーター"
+          >
+            {slides.map((_, i) => (
+              <div
+                // indicator only (no click per spec)
+                key={i}
+                className="h-2 w-2 rounded-full"
+                style={{
+                  backgroundColor:
+                    i === index ? "var(--gold-bright)" : "var(--gold-dim)",
+                  opacity: i === index ? 1 : 0.35,
+                }}
+              />
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={!canNext}
+            className="h-10 w-10 rounded-full border border-[color:var(--gold)]/25 bg-black/20 backdrop-blur-sm transition-opacity disabled:opacity-30"
+            aria-label="次のページ"
+          >
+            <ChevronRight className="mx-auto h-5 w-5 text-[color:var(--gold-bright)]" />
+          </button>
         </div>
       </div>
     </main>
   );
 }
 
-function SimpleStep({ num, text }: { num: string; text: string }) {
+function SlideContent({ slide }: { slide: TutorialSlide }) {
   return (
-    <li className="flex items-start gap-4">
-      <span className="text-xl font-bold tracking-[0.2em] text-[color:var(--gold)]/40 border-b border-[color:var(--gold)]/20 pb-1">
-        {num}
-      </span>
-      <p className="text-sm font-medium tracking-wide text-[color:var(--foreground)]/80 mt-1">
-        {text}
+    <div className="h-full w-full p-6 flex flex-col items-center justify-center gap-6">
+      <div className="relative w-full max-w-sm aspect-[4/3] overflow-hidden rounded-xl border border-[color:var(--gold)]/15">
+        <Image
+          src={slide.imageSrc}
+          alt={slide.imageAlt}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 80vw, 420px"
+          priority
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0.15), rgba(0,0,0,0.55))",
+          }}
+          aria-hidden="true"
+        />
+      </div>
+
+      <p className="text-center text-base leading-relaxed tracking-wide text-[color:var(--foreground)]/90">
+        {slide.description}
       </p>
-    </li>
+    </div>
   );
 }

--- a/src/app/tutorial/page.tsx
+++ b/src/app/tutorial/page.tsx
@@ -161,7 +161,7 @@ export default function TutorialPage() {
   }, [phase]);
 
   return (
-    <main className="relative min-h-svh w-full overflow-hidden bg-[color:var(--background)] text-[color:var(--foreground)]">
+    <main className="relative h-svh w-full overflow-hidden overscroll-none bg-[color:var(--background)] text-[color:var(--foreground)]">
       {/* Background layers (match Home ambience) */}
       <div
         className="fixed inset-0"
@@ -183,7 +183,7 @@ export default function TutorialPage() {
 
       <FloatingParticles />
 
-      <div className="relative z-20 min-h-svh px-10 py-8">
+      <div className="relative z-20 h-full overflow-hidden px-10">
         {/* Back link (match Play/Settings style) */}
         <Link
           href="/home"
@@ -204,7 +204,7 @@ export default function TutorialPage() {
         </header>
 
         {/* Center area (carousel) */}
-        <div className="min-h-svh flex items-center justify-center">
+        <div className="h-full flex items-center justify-center">
           <div className="w-full max-w-sm">
             <div className="relative overflow-hidden rounded-2xl border border-[color:var(--gold)]/15 bg-black/20 backdrop-blur-sm">
               <div className="relative h-[360px]">

--- a/src/app/tutorial/tutorial-theme.module.css
+++ b/src/app/tutorial/tutorial-theme.module.css
@@ -1,4 +1,6 @@
 .theme {
+  height: 100svh;
+  overflow: hidden;
   color-scheme: dark;
 
   /* Dark medieval palette (scoped to /tutorial) */

--- a/src/app/tutorial/tutorial-theme.module.css
+++ b/src/app/tutorial/tutorial-theme.module.css
@@ -2,8 +2,8 @@
   color-scheme: dark;
 
   /* Dark medieval palette (scoped to /tutorial) */
-  --background: oklch(0.13 0.02 250);
-  --foreground: oklch(0.92 0.03 85);
+  --background: #1a1a2e;
+  --foreground: #ededed;
 
   --gold: oklch(0.78 0.12 85);
   --gold-dim: oklch(0.55 0.1 85);

--- a/src/app/tutorial/tutorial-theme.module.css
+++ b/src/app/tutorial/tutorial-theme.module.css
@@ -2,8 +2,8 @@
   color-scheme: dark;
 
   /* Dark medieval palette (scoped to /tutorial) */
-  --background: #1a1a2e;
-  --foreground: #ededed;
+  --background: oklch(0.13 0.02 250);
+  --foreground: oklch(0.92 0.03 85);
 
   --gold: oklch(0.78 0.12 85);
   --gold-dim: oklch(0.55 0.1 85);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チュートリアルをマルチスライドのカルーセルに刷新（中央表示・背景演出を含む）
  * スライド間のアニメーション遷移と前後ボタン、ページ指示器を追加
  * 矢印キーによるキーボードナビゲーションを実装
  * 画像読み込み失敗時のフォールバック表示を追加
  * 動作抑制（Reduced Motion）向けのアクセシビリティ対応を導入
* **Style**
  * チュートリアル領域の高さとスクロール挙動を固定してオーバーフローを防止
<!-- end of auto-generated comment: release notes by coderabbit.ai -->