### PR TITLE
feat: 音声認識おみくじ機能を追加し、Tapoクライアントのキャッシュリセット機能を実装

### DIFF
--- a/src/app/test/phomemo/page.tsx
+++ b/src/app/test/phomemo/page.tsx
@@ -1,7 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { usePhomemo } from "@/features/iot/api/usePhomemo";
+import { useSpeech } from "@/features/voice/api/useSpeech";
+import { SPELL_DICTIONARY } from "@/features/voice/lib/spell-matcher";
+
+const OMIKUJI_MESSAGES = [
+  {
+    fortune: "大吉",
+    message: "魔法が最高に冴える日！\n何でも叶う最強の一日。",
+  },
+  {
+    fortune: "中吉",
+    message: "良い流れが来ている。\nゆっくり進めば夢に近づく。",
+  },
+  { fortune: "小吉", message: "小さな幸せが積み重なる日。\n丁寧に過ごそう。" },
+  { fortune: "末吉", message: "焦らず待てば好機が来る。\n今日は準備の日。" },
+  { fortune: "凶", message: "無理は禁物。\n休息が次の魔法を生む。" },
+];
+
+function drawOmikuji(): string {
+  const picked =
+    OMIKUJI_MESSAGES[Math.floor(Math.random() * OMIKUJI_MESSAGES.length)];
+  return `【${picked.fortune}】
+${picked.message}`;
+}
 
 const STATUS_EMOJI: Record<string, string> = {
   DISCONNECTED: "🔌",
@@ -21,6 +44,9 @@ const STATUS_LABEL: Record<string, string> = {
 
 export default function PhomemoTestPage() {
   const [printMessage, setPrintMessage] = useState("今日の運勢は大吉");
+  const [voiceStatus, setVoiceStatus] = useState("待機中");
+  const [showConnectModal, setShowConnectModal] = useState(false);
+  const lastVoiceKeyRef = useRef<string>("");
   const {
     status,
     deviceName,
@@ -31,6 +57,45 @@ export default function PhomemoTestPage() {
     printTestPage,
     isConnected,
   } = usePhomemo();
+
+  // おみくじ呪文のみを対象とする辞書
+  const omikujiSpells = SPELL_DICTIONARY.filter(
+    (s) => s.id === "kyua_uppu_rapa_pa",
+  );
+  const { transcript, spellMatch, start, stop, isSupported } =
+    useSpeech(omikujiSpells);
+
+  useEffect(() => {
+    if (!spellMatch?.matched || !spellMatch.spell) return;
+    if (spellMatch.spell.id !== "kyua_uppu_rapa_pa") return;
+
+    const key = `${spellMatch.spell.id}:${spellMatch.rawTranscript}`;
+    if (lastVoiceKeyRef.current === key) return;
+    lastVoiceKeyRef.current = key;
+
+    stop();
+    setVoiceStatus(`✨ 認識: ${spellMatch.spell.name}`);
+
+    if (!isConnected) {
+      setVoiceStatus("❌ プリンターが未接続です");
+      setShowConnectModal(true);
+      return;
+    }
+
+    const message = drawOmikuji();
+    printTestPage(message)
+      .then(() => {
+        setVoiceStatus("🎉 おみくじ印刷完了！");
+      })
+      .catch(() => {
+        setVoiceStatus("❌ 印刷に失敗しました");
+      });
+  }, [spellMatch]);
+
+  // 接続完了でモーダルを自動クローズ
+  useEffect(() => {
+    if (isConnected) setShowConnectModal(false);
+  }, [isConnected]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 p-8">
@@ -119,6 +184,51 @@ export default function PhomemoTestPage() {
           </div>
         </div>
 
+        {/* 音声認識おみくじ */}
+        <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-6 mt-6 border border-white/20">
+          <h2 className="text-xl font-semibold text-white mb-4">
+            🎤 音声おみくじ
+          </h2>
+          <p className="text-blue-200 text-sm mb-4">
+            「キュアップラパパ！今日のおみくじ！」と唱えると印刷します
+          </p>
+          <div className="flex gap-3 mb-4">
+            <button
+              onClick={() => {
+                if (!isConnected) {
+                  setShowConnectModal(true);
+                  return;
+                }
+                lastVoiceKeyRef.current = "";
+                start();
+                setVoiceStatus("🎙️ 認識中...");
+              }}
+              disabled={!isSupported}
+              className="flex-1 bg-pink-500 hover:bg-pink-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-3 px-4 rounded-xl transition-all transform hover:scale-105 active:scale-95 disabled:transform-none"
+            >
+              🎤 音声認識開始
+            </button>
+            <button
+              onClick={() => {
+                stop();
+                setVoiceStatus("停止中");
+              }}
+              className="flex-1 bg-slate-500 hover:bg-slate-600 text-white font-bold py-3 px-4 rounded-xl transition-all transform hover:scale-105 active:scale-95"
+            >
+              ⏹ 停止
+            </button>
+          </div>
+          <div className="bg-black/20 rounded-xl p-4 space-y-1 text-sm">
+            <p className="text-gray-300">
+              <strong className="text-white">状態:</strong> {voiceStatus}
+            </p>
+            <p className="text-gray-300">
+              <strong className="text-white">認識テキスト:</strong>{" "}
+              {transcript || "（まだ認識なし）"}
+            </p>
+          </div>
+        </div>
+
         {/* 使い方ガイド */}
         <div className="bg-white/5 backdrop-blur-lg rounded-2xl p-6 mt-6 border border-white/10">
           <h3 className="text-lg font-semibold text-white mb-3">
@@ -129,6 +239,7 @@ export default function PhomemoTestPage() {
             <li>「デバイスに接続する」ボタンをクリック</li>
             <li>ブラウザのダイアログで「M02S」を選択</li>
             <li>接続後にメッセージを入力して「テスト印刷する」を押す</li>
+            <li>または「音声認識開始」を押して呪文を唱える</li>
           </ol>
           <div className="mt-4 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
             <p className="text-yellow-200 text-xs">
@@ -137,6 +248,43 @@ export default function PhomemoTestPage() {
           </div>
         </div>
       </div>
+
+      {/* 未接続モーダル */}
+      {showConnectModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="bg-gradient-to-br from-purple-900 to-indigo-900 border border-white/20 rounded-2xl p-8 max-w-sm w-full mx-4 shadow-2xl">
+            <div className="text-center mb-6">
+              <p className="text-5xl mb-4">🖨️</p>
+              <h3 className="text-xl font-bold text-white mb-2">
+                プリンターが未接続です
+              </h3>
+              <p className="text-blue-200 text-sm">
+                音声認識を使うには、Phomemo M02S に接続してください。
+              </p>
+            </div>
+            <div className="space-y-3">
+              <button
+                onClick={() => {
+                  setShowConnectModal(false);
+                  connect();
+                }}
+                disabled={status === "CONNECTING"}
+                className="w-full bg-blue-500 hover:bg-blue-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-3 px-6 rounded-xl transition-all"
+              >
+                {status === "CONNECTING"
+                  ? "🔄 接続中..."
+                  : "📱 プリンターに接続する"}
+              </button>
+              <button
+                onClick={() => setShowConnectModal(false)}
+                className="w-full bg-white/10 hover:bg-white/20 text-gray-300 font-medium py-3 px-6 rounded-xl transition-all"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/test/phomemo/page.tsx
+++ b/src/app/test/phomemo/page.tsx
@@ -62,19 +62,19 @@ export default function PhomemoTestPage() {
   const omikujiSpells = SPELL_DICTIONARY.filter(
     (s) => s.id === "kyua_uppu_rapa_pa",
   );
-  const { transcript, spellMatch, start, stop, isSupported } =
+  const { transcript, finalSpellMatch, start, stop, isSupported } =
     useSpeech(omikujiSpells);
 
   useEffect(() => {
-    if (!spellMatch?.matched || !spellMatch.spell) return;
-    if (spellMatch.spell.id !== "kyua_uppu_rapa_pa") return;
+    if (!finalSpellMatch?.matched || !finalSpellMatch.spell) return;
+    if (finalSpellMatch.spell.id !== "kyua_uppu_rapa_pa") return;
 
-    const key = `${spellMatch.spell.id}:${spellMatch.rawTranscript}`;
+    const key = `${finalSpellMatch.spell.id}:${finalSpellMatch.rawTranscript}`;
     if (lastVoiceKeyRef.current === key) return;
     lastVoiceKeyRef.current = key;
 
     stop();
-    setVoiceStatus(`✨ 認識: ${spellMatch.spell.name}`);
+    setVoiceStatus(`✨ 認識: ${finalSpellMatch.spell.name}`);
 
     if (!isConnected) {
       setVoiceStatus("❌ プリンターが未接続です");
@@ -90,7 +90,7 @@ export default function PhomemoTestPage() {
       .catch(() => {
         setVoiceStatus("❌ 印刷に失敗しました");
       });
-  }, [spellMatch]);
+  }, [finalSpellMatch, isConnected, printTestPage, stop]);
 
   // 接続完了でモーダルを自動クローズ
   useEffect(() => {

--- a/src/app/test/phomemo/page.tsx
+++ b/src/app/test/phomemo/page.tsx
@@ -42,11 +42,17 @@ const STATUS_LABEL: Record<string, string> = {
   ERROR: "エラー",
 };
 
+const CHANT_TIMEOUT_MS = 10000;
+
 export default function PhomemoTestPage() {
   const [printMessage, setPrintMessage] = useState("今日の運勢は大吉");
   const [voiceStatus, setVoiceStatus] = useState("待機中");
   const [showConnectModal, setShowConnectModal] = useState(false);
+  const [showChantFailModal, setShowChantFailModal] = useState(false);
+  const [chantFailMessage, setChantFailMessage] = useState("");
+  const [isVoiceListening, setIsVoiceListening] = useState(false);
   const lastVoiceKeyRef = useRef<string>("");
+  const chantTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const {
     status,
     deviceName,
@@ -62,8 +68,26 @@ export default function PhomemoTestPage() {
   const omikujiSpells = SPELL_DICTIONARY.filter(
     (s) => s.id === "kyua_uppu_rapa_pa",
   );
-  const { transcript, finalSpellMatch, start, stop, isSupported } =
-    useSpeech(omikujiSpells);
+  const {
+    transcript,
+    finalSpellMatch,
+    start,
+    stop,
+    isSupported,
+    status: speechStatus,
+  } = useSpeech(omikujiSpells);
+
+  const clearChantTimeout = () => {
+    if (chantTimeoutRef.current) {
+      clearTimeout(chantTimeoutRef.current);
+      chantTimeoutRef.current = null;
+    }
+  };
+
+  const showChantFailed = (message: string) => {
+    setChantFailMessage(message);
+    setShowChantFailModal(true);
+  };
 
   useEffect(() => {
     if (!finalSpellMatch?.matched || !finalSpellMatch.spell) return;
@@ -73,6 +97,8 @@ export default function PhomemoTestPage() {
     if (lastVoiceKeyRef.current === key) return;
     lastVoiceKeyRef.current = key;
 
+    clearChantTimeout();
+    setIsVoiceListening(false);
     stop();
     setVoiceStatus(`✨ 認識: ${finalSpellMatch.spell.name}`);
 
@@ -92,10 +118,27 @@ export default function PhomemoTestPage() {
       });
   }, [finalSpellMatch, isConnected, printTestPage, stop]);
 
+  useEffect(() => {
+    if (speechStatus !== "ERROR" || !isVoiceListening) return;
+
+    clearChantTimeout();
+    setIsVoiceListening(false);
+    setVoiceStatus("❌ 音声認識エラー");
+    showChantFailed(
+      "詠唱の認識中にエラーが発生しました。マイク権限や周囲の騒音を確認して、もう一度お試しください。",
+    );
+  }, [speechStatus, isVoiceListening]);
+
   // 接続完了でモーダルを自動クローズ
   useEffect(() => {
     if (isConnected) setShowConnectModal(false);
   }, [isConnected]);
+
+  useEffect(() => {
+    return () => {
+      clearChantTimeout();
+    };
+  }, []);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 p-8">
@@ -200,8 +243,19 @@ export default function PhomemoTestPage() {
                   return;
                 }
                 lastVoiceKeyRef.current = "";
+                setShowChantFailModal(false);
+                setIsVoiceListening(true);
                 start();
                 setVoiceStatus("🎙️ 認識中...");
+                clearChantTimeout();
+                chantTimeoutRef.current = setTimeout(() => {
+                  stop();
+                  setIsVoiceListening(false);
+                  setVoiceStatus("❌ 呪文を認識できませんでした");
+                  showChantFailed(
+                    "詠唱が確認できませんでした。『キュアップラパパ、今日のおみくじ』と、はっきり続けて唱えてみてください。",
+                  );
+                }, CHANT_TIMEOUT_MS);
               }}
               disabled={!isSupported}
               className="flex-1 bg-pink-500 hover:bg-pink-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-3 px-4 rounded-xl transition-all transform hover:scale-105 active:scale-95 disabled:transform-none"
@@ -210,8 +264,16 @@ export default function PhomemoTestPage() {
             </button>
             <button
               onClick={() => {
+                const wasListening = isVoiceListening;
                 stop();
+                clearChantTimeout();
+                setIsVoiceListening(false);
                 setVoiceStatus("停止中");
+                if (wasListening) {
+                  showChantFailed(
+                    "詠唱が途中で停止されました。もう一度、最後まで呪文を唱えてください。",
+                  );
+                }
               }}
               className="flex-1 bg-slate-500 hover:bg-slate-600 text-white font-bold py-3 px-4 rounded-xl transition-all transform hover:scale-105 active:scale-95"
             >
@@ -277,6 +339,57 @@ export default function PhomemoTestPage() {
               </button>
               <button
                 onClick={() => setShowConnectModal(false)}
+                className="w-full bg-white/10 hover:bg-white/20 text-gray-300 font-medium py-3 px-6 rounded-xl transition-all"
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 詠唱失敗モーダル */}
+      {showChantFailModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="bg-gradient-to-br from-rose-900 to-orange-900 border border-white/20 rounded-2xl p-8 max-w-sm w-full mx-4 shadow-2xl">
+            <div className="text-center mb-6">
+              <p className="text-5xl mb-4">🪄</p>
+              <h3 className="text-xl font-bold text-white mb-2">
+                詠唱に失敗しました
+              </h3>
+              <p className="text-orange-100 text-sm whitespace-pre-line">
+                {chantFailMessage}
+              </p>
+            </div>
+            <div className="space-y-3">
+              <button
+                onClick={() => {
+                  setShowChantFailModal(false);
+                  if (!isConnected) {
+                    setShowConnectModal(true);
+                    return;
+                  }
+                  lastVoiceKeyRef.current = "";
+                  setIsVoiceListening(true);
+                  start();
+                  setVoiceStatus("🎙️ 認識中...");
+                  clearChantTimeout();
+                  chantTimeoutRef.current = setTimeout(() => {
+                    stop();
+                    setIsVoiceListening(false);
+                    setVoiceStatus("❌ 呪文を認識できませんでした");
+                    showChantFailed(
+                      "詠唱が確認できませんでした。『キュアップラパパ、今日のおみくじ』と、はっきり続けて唱えてみてください。",
+                    );
+                  }, CHANT_TIMEOUT_MS);
+                }}
+                disabled={!isSupported}
+                className="w-full bg-orange-500 hover:bg-orange-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-3 px-6 rounded-xl transition-all"
+              >
+                🎤 もう一度 詠唱する
+              </button>
+              <button
+                onClick={() => setShowChantFailModal(false)}
                 className="w-full bg-white/10 hover:bg-white/20 text-gray-300 font-medium py-3 px-6 rounded-xl transition-all"
               >
                 閉じる

--- a/src/features/iot/api/tapoClient.ts
+++ b/src/features/iot/api/tapoClient.ts
@@ -5,6 +5,11 @@ const IS_TEST_ENV = process.env.NODE_ENV === "test";
 let cachedClient: Awaited<ReturnType<typeof loginDeviceByIp>> | null = null;
 let cachedClientKey: string | null = null;
 
+export function resetTapoClientCache() {
+  cachedClient = null;
+  cachedClientKey = null;
+}
+
 export async function getTapoClient(): Promise<
   Awaited<ReturnType<typeof loginDeviceByIp>>
 > {

--- a/src/features/iot/lib/plugControl.ts
+++ b/src/features/iot/lib/plugControl.ts
@@ -186,7 +186,9 @@ async function togglePort(
     return await runOnce();
   } catch (error) {
     if (!IS_TEST_ENV && isAuthError(error)) {
-      console.warn("⚠️ 認証エラーを検知。Tapoセッションを再取得して再試行します");
+      console.warn(
+        "⚠️ 認証エラーを検知。Tapoセッションを再取得して再試行します",
+      );
       resetTapoClientCache();
       clearChildDevicesCache();
 

--- a/src/features/iot/lib/plugControl.ts
+++ b/src/features/iot/lib/plugControl.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getTapoClient } from "../api/tapoClient";
+import { getTapoClient, resetTapoClientCache } from "../api/tapoClient";
 
 // ========================================
 // 簡易ジョブスケジューラー（自動OFFタイマー管理）
@@ -107,6 +107,16 @@ async function getCachedChildDevices(
   return items;
 }
 
+function clearChildDevicesCache() {
+  childDevicesCache = null;
+}
+
+function isAuthError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const maybeResponse = (error as { response?: { status?: number } }).response;
+  return maybeResponse?.status === 401 || maybeResponse?.status === 403;
+}
+
 // ========================================
 // 内部ヘルパー関数
 // ========================================
@@ -124,7 +134,7 @@ async function togglePort(
   spellName: string,
   emoji: string,
 ) {
-  try {
+  const runOnce = async () => {
     if (!turnOn) {
       cancelScheduledJob(portIndex);
     }
@@ -170,7 +180,29 @@ async function togglePort(
       success: true,
       message: `${spellName}成功！ポート${portIndex}を${turnOn ? "ON" : "OFF"}にしました${emoji}`,
     };
+  };
+
+  try {
+    return await runOnce();
   } catch (error) {
+    if (!IS_TEST_ENV && isAuthError(error)) {
+      console.warn("⚠️ 認証エラーを検知。Tapoセッションを再取得して再試行します");
+      resetTapoClientCache();
+      clearChildDevicesCache();
+
+      try {
+        return await runOnce();
+      } catch (retryError) {
+        console.error(`❌ ${spellName}再試行失敗:`, retryError);
+        const retryMessage =
+          retryError instanceof Error ? retryError.message : String(retryError);
+        return {
+          success: false,
+          message: `${spellName}失敗: ${retryMessage}`,
+        };
+      }
+    }
+
     console.error(`❌ ${spellName}失敗:`, error);
     const errorMessage = error instanceof Error ? error.message : String(error);
     return { success: false, message: `${spellName}失敗: ${errorMessage}` };

--- a/src/features/voice/api/useSpeech.ts
+++ b/src/features/voice/api/useSpeech.ts
@@ -17,6 +17,8 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
   const [status, setStatus] = useState<SpeechStatus>("IDLE");
   const [result, setResult] = useState<SpeechResult | null>(null);
   const [spellMatch, setSpellMatch] = useState<SpellMatchResult | null>(null);
+  const [finalSpellMatch, setFinalSpellMatch] =
+    useState<SpellMatchResult | null>(null);
   const [transcript, setTranscript] = useState<string>("");
   const [isSupported, setIsSupported] = useState(false);
   const removeListenerRef = useRef<(() => void) | null>(null);
@@ -32,6 +34,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
     }
 
     setSpellMatch(null);
+  setFinalSpellMatch(null);
     setTranscript("");
     hasDispatchedMatchRef.current = false;
     setStatus("LISTENING");
@@ -54,6 +57,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
           if (res.isFinal) {
             // final結果: 信頼度を問わず確定させ、ロック
             setSpellMatch(match);
+            setFinalSpellMatch(match);
             hasDispatchedMatchRef.current = true;
           } else if (
             !hasDispatchedMatchRef.current &&
@@ -84,6 +88,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
   const stop = useCallback(() => {
     speechRecognitionAPI.stop();
     hasDispatchedMatchRef.current = false;
+    setFinalSpellMatch(null);
     if (removeListenerRef.current) {
       removeListenerRef.current();
       removeListenerRef.current = null;
@@ -107,6 +112,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
     status,
     result,
     spellMatch,
+    finalSpellMatch,
     transcript,
     start,
     stop,

--- a/src/features/voice/api/useSpeech.ts
+++ b/src/features/voice/api/useSpeech.ts
@@ -34,7 +34,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
     }
 
     setSpellMatch(null);
-  setFinalSpellMatch(null);
+    setFinalSpellMatch(null);
     setTranscript("");
     hasDispatchedMatchRef.current = false;
     setStatus("LISTENING");

--- a/src/features/voice/api/useSpeech.ts
+++ b/src/features/voice/api/useSpeech.ts
@@ -18,6 +18,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
   const [result, setResult] = useState<SpeechResult | null>(null);
   const [spellMatch, setSpellMatch] = useState<SpellMatchResult | null>(null);
   const [transcript, setTranscript] = useState<string>("");
+  const [isSupported, setIsSupported] = useState(false);
   const removeListenerRef = useRef<(() => void) | null>(null);
   const hasDispatchedMatchRef = useRef(false);
 
@@ -92,6 +93,7 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
 
   // コンポーネントのアンマウント時に停止
   useEffect(() => {
+    setIsSupported(speechRecognitionAPI.isSupported());
     return () => {
       if (removeListenerRef.current) {
         removeListenerRef.current();
@@ -108,6 +110,6 @@ export function useSpeech(spells: SpellEntry[] = SPELL_DICTIONARY) {
     transcript,
     start,
     stop,
-    isSupported: speechRecognitionAPI.isSupported(),
+    isSupported,
   };
 }

--- a/src/features/voice/lib/spell-matcher.ts
+++ b/src/features/voice/lib/spell-matcher.ts
@@ -37,6 +37,21 @@ export const SPELL_DICTIONARY: SpellEntry[] = [
     action: "fan_on",
   },
   {
+    id: "kyua_uppu_rapa_pa",
+    name: "キュアップラパパ",
+    keywords: [
+      "キュアップラパパ",
+      "きゅあっぷらぱぱ",
+      "キュアップラパ",
+      "きゅあっぷらぱ",
+      "キュアップ",
+      "おみくじ",
+      "今日のおみくじ",
+      "キュアップラパパ今日のおみくじ",
+    ],
+    action: "print_omikuji",
+  },
+  {
     id: "incendio",
     name: "インセンディオ",
     keywords: [

--- a/src/features/voice/lib/spell-matcher.ts
+++ b/src/features/voice/lib/spell-matcher.ts
@@ -42,12 +42,10 @@ export const SPELL_DICTIONARY: SpellEntry[] = [
     keywords: [
       "キュアップラパパ",
       "きゅあっぷらぱぱ",
-      "キュアップラパ",
-      "きゅあっぷらぱ",
-      "キュアップ",
-      "おみくじ",
-      "今日のおみくじ",
       "キュアップラパパ今日のおみくじ",
+      "きゅあっぷらぱぱきょうのおみくじ",
+      "キュアップラパパ今日のおみくじお願いします",
+      "きゅあっぷらぱぱきょうのおみくじおねがいします",
     ],
     action: "print_omikuji",
   },
@@ -142,11 +140,12 @@ export function matchSpell(
   for (const spell of dictionary) {
     for (const keyword of spell.keywords) {
       const normalizedKeyword = normalizeForMatch(keyword);
+      const allowReversePartial = spell.id !== "kyua_uppu_rapa_pa";
 
       // キーワードが3文字以上、または特定の重要な呪文の場合にのみ部分一致を許容するなどの工夫も可能
       if (
         normalized.includes(normalizedKeyword) ||
-        normalizedKeyword.includes(normalized)
+        (allowReversePartial && normalizedKeyword.includes(normalized))
       ) {
         return {
           matched: true,

--- a/src/tests/features/voice/spellMatcher.test.ts
+++ b/src/tests/features/voice/spellMatcher.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  matchSpell,
+  SPELL_DICTIONARY,
+} from "@/features/voice/lib/spell-matcher";
+
+describe("Spell matcher: kyua_uppu_rapa_pa strict matching", () => {
+  it("matches full phrase variants intentionally", () => {
+    const exact = matchSpell("キュアップラパパ", SPELL_DICTIONARY);
+    const withOmikuji = matchSpell(
+      "キュアップラパパ 今日のおみくじ",
+      SPELL_DICTIONARY,
+    );
+
+    expect(exact.matched).toBe(true);
+    expect(exact.spell?.id).toBe("kyua_uppu_rapa_pa");
+    expect(withOmikuji.matched).toBe(true);
+    expect(withOmikuji.spell?.id).toBe("kyua_uppu_rapa_pa");
+  });
+
+  it("does not match generic or incomplete utterances", () => {
+    const genericOmikuji = matchSpell("おみくじ", SPELL_DICTIONARY);
+    const genericKyua = matchSpell("キュアップ", SPELL_DICTIONARY);
+
+    expect(genericOmikuji.matched).toBe(false);
+    expect(genericKyua.matched).toBe(false);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 音声で呼び出す「おみくじ」機能を追加。開始/停止や状態・文字起こしの表示を備えた専用UIを実装しました。

* **改善**
  * プリンタ接続のモーダル表示を導入し、接続成功時に自動で閉じるなど接続体験を向上しました。
  * 音声認識の対応状況を明示表示するようにしました。

* **バグ修正**
  * 認証エラー発生時の自動再試行とキャッシュのクリアで接続失敗の復旧性を改善しました。

* **テスト**
  * 新しい音声フレーズの一致挙動を確認する単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->